### PR TITLE
Using docker registry instead of gcr, on smoke tests

### DIFF
--- a/smoke.json
+++ b/smoke.json
@@ -1,3 +1,3 @@
 {
-  "procfile" :  "gcr.io/paketo-buildpacks/procfile"
+  "procfile" :  "index.docker.io/paketobuildpacks/procfile"
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR uses docker registry for fetching procfile buildpack during smoke tests.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
